### PR TITLE
Improve cleanup commands and more

### DIFF
--- a/io.github.swordpuffin.rewaita.json
+++ b/io.github.swordpuffin.rewaita.json
@@ -1,10 +1,10 @@
 {
-    "id" : "io.github.swordpuffin.rewaita",
-    "runtime" : "org.gnome.Platform",
-    "runtime-version" : "50",
-    "sdk" : "org.gnome.Sdk",
-    "command" : "rewaita",
-    "finish-args" : [
+    "id": "io.github.swordpuffin.rewaita",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "50",
+    "sdk": "org.gnome.Sdk",
+    "command": "rewaita",
+    "finish-args": [
         "--share=ipc",
         "--socket=fallback-x11",
         "--device=dri",
@@ -22,124 +22,51 @@
         "--filesystem=~/.var/app/net.waterfox.waterfox/.waterfox",
         "--filesystem=~/snap/firefox/common/.mozilla/firefox"
     ],
-    "cleanup" : [
+    "cleanup": [
         "/include",
         "/lib/pkgconfig",
-        "/man",
+        "/lib/python3.??/*/numpy/tests",
+        "/lib/python3.??/*/numpy/*/tests",
         "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
+        "/share/gir-1.0",
+        "/share/vala"
     ],
-    "modules" : [
+    "modules": [
+        "python3-modules.json",
         {
-            "name" : "python3-modules",
-            "buildsystem" : "simple",
-            "build-commands" : [],
-            "modules" : [
+            "name": "libportal",
+            "buildsystem": "meson",
+            "sources": [
                 {
-                    "name" : "python3-pillow",
-                    "buildsystem" : "simple",
-                    "build-commands" : [
-                        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pillow\" --no-build-isolation"
-                    ],
-                    "sources" : [
-                        {
-                            "type" : "file",
-                            "url" : "https://files.pythonhosted.org/packages/f3/0d/d0d6dea55cd152ce3d6767bb38a8fc10e33796ba4ba210cbab9354b6d238/pillow-11.3.0.tar.gz",
-                            "sha256" : "3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523"
-                        }
-                    ]
-                },
-                {
-                    "name" : "python3-meson-python",
-                    "buildsystem" : "simple",
-                    "build-commands" : [
-                        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"meson-python\" --no-build-isolation"
-                    ],
-                    "sources" : [
-                        {
-                            "type" : "file",
-                            "url" : "https://files.pythonhosted.org/packages/28/58/66db620a8a7ccb32633de9f403fe49f1b63c68ca94e5c340ec5cceeb9821/meson_python-0.18.0-py3-none-any.whl",
-                            "sha256" : "3b0fe051551cc238f5febb873247c0949cd60ded556efa130aa57021804868e2"
-                        },
-                        {
-                            "type" : "file",
-                            "url" : "https://files.pythonhosted.org/packages/7e/b1/8e63033b259e0a4e40dd1ec4a9fee17718016845048b43a36ec67d62e6fe/pyproject_metadata-0.9.1-py3-none-any.whl",
-                            "sha256" : "ee5efde548c3ed9b75a354fc319d5afd25e9585fa918a34f62f904cc731973ad"
-                        }
-                    ]
-                },
-                {
-                    "name" : "python3-numpy",
-                    "buildsystem" : "simple",
-                    "build-commands" : [
-                        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"numpy\" --no-build-isolation"
-                    ],
-                    "sources" : [
-                        {
-                            "type" : "file",
-                            "url" : "https://files.pythonhosted.org/packages/d0/19/95b3d357407220ed24c139018d2518fab0a61a948e68286a25f1a4d049ff/numpy-2.3.3.tar.gz",
-                            "sha256" : "ddc7c39727ba62b80dfdbedf400d1c10ddfa8eefbd7ec8dcb118be8b56d31029"
-                        }
-                    ]
-                },
-                {
-                    "name" : "python3-fortune-python",
-                    "buildsystem" : "simple",
-                    "build-commands" : [
-                        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"fortune-python\" --no-build-isolation"
-                    ],
-                    "sources" : [
-                        {
-                            "type" : "file",
-                            "url" : "https://files.pythonhosted.org/packages/2b/e9/00d33f62194d30954b101fc382df64c62e4593645d15738cd7bc56d2484c/fortune_python-1.1.2-py3-none-any.whl",
-                            "sha256" : "5f64f6fb9f4aae1471bd4ce1c65e99582479b6bc43996120c4064f87f08a13bc"
-                        }
-                    ]
-                },
-                {
-                    "name" : "python3-pyciede2000",
-                    "buildsystem" : "simple",
-                    "build-commands" : [
-                        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pyciede2000\" --no-build-isolation"
-                    ],
-                    "sources" : [
-                        {
-                            "type" : "file",
-                            "url" : "https://files.pythonhosted.org/packages/f9/e3/b52ecf4711a92187ffa16e8f433af0b32fce7bcc3b8c00543f0592abaa72/pyciede2000-0.0.21-py3-none-any.whl",
-                            "sha256" : "da570372b2c58902b5627568ec3ca2ac2c523d74790022069f89a3b626083d1a"
-                        }
-                    ]
+                    "type": "git",
+                    "url": "https://github.com/flatpak/libportal.git",
+                    "tag": "0.9.1",
+                    "commit": "8f5dc8d192f6e31dafe69e35219e3b707bde71ce",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "semantic"
+                    }
                 }
             ]
         },
         {
-            "name" : "libportal",
-            "buildsystem" : "meson",
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://github.com/flatpak/libportal.git",
-                    "tag" : "0.9.1"
-                }
-            ]
-        },
-        {
-            "name" : "rewaita",
-            "builddir" : true,
-            "buildsystem" : "meson",
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://github.com/SwordPuffin/Rewaita.git",
-                    "tag" : "v1.1.2"
-                }
-            ],
-            "config-opts" : [
+            "name": "rewaita",
+            "builddir": true,
+            "buildsystem": "meson",
+            "config-opts": [
                 "--libdir=lib"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/SwordPuffin/Rewaita.git",
+                    "tag": "v1.1.2",
+                    "commit": "3a9e3b9b3bf711f27e862996a08f8bbcb98f5f70",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
+                }
             ]
         }
     ]

--- a/python3-modules.json
+++ b/python3-modules.json
@@ -1,0 +1,82 @@
+{
+    "name" : "python3-modules",
+    "buildsystem" : "simple",
+    "build-commands" : [],
+    "modules" : [
+        {
+            "name" : "python3-pillow",
+            "buildsystem" : "simple",
+            "build-commands" : [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pillow\" --no-build-isolation"
+            ],
+            "sources" : [
+                {
+                    "type" : "file",
+                    "url" : "https://files.pythonhosted.org/packages/f3/0d/d0d6dea55cd152ce3d6767bb38a8fc10e33796ba4ba210cbab9354b6d238/pillow-11.3.0.tar.gz",
+                    "sha256" : "3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523"
+                }
+            ]
+        },
+        {
+            "name" : "python3-meson-python",
+            "buildsystem" : "simple",
+            "build-commands" : [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"meson-python\" --no-build-isolation"
+            ],
+            "sources" : [
+                {
+                    "type" : "file",
+                    "url" : "https://files.pythonhosted.org/packages/28/58/66db620a8a7ccb32633de9f403fe49f1b63c68ca94e5c340ec5cceeb9821/meson_python-0.18.0-py3-none-any.whl",
+                    "sha256" : "3b0fe051551cc238f5febb873247c0949cd60ded556efa130aa57021804868e2"
+                },
+                {
+                    "type" : "file",
+                    "url" : "https://files.pythonhosted.org/packages/7e/b1/8e63033b259e0a4e40dd1ec4a9fee17718016845048b43a36ec67d62e6fe/pyproject_metadata-0.9.1-py3-none-any.whl",
+                    "sha256" : "ee5efde548c3ed9b75a354fc319d5afd25e9585fa918a34f62f904cc731973ad"
+                }
+            ]
+        },
+        {
+            "name" : "python3-numpy",
+            "buildsystem" : "simple",
+            "build-commands" : [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"numpy\" --no-build-isolation"
+            ],
+            "sources" : [
+                {
+                    "type" : "file",
+                    "url" : "https://files.pythonhosted.org/packages/d0/19/95b3d357407220ed24c139018d2518fab0a61a948e68286a25f1a4d049ff/numpy-2.3.3.tar.gz",
+                    "sha256" : "ddc7c39727ba62b80dfdbedf400d1c10ddfa8eefbd7ec8dcb118be8b56d31029"
+                }
+            ]
+        },
+        {
+            "name" : "python3-fortune-python",
+            "buildsystem" : "simple",
+            "build-commands" : [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"fortune-python\" --no-build-isolation"
+            ],
+            "sources" : [
+                {
+                    "type" : "file",
+                    "url" : "https://files.pythonhosted.org/packages/2b/e9/00d33f62194d30954b101fc382df64c62e4593645d15738cd7bc56d2484c/fortune_python-1.1.2-py3-none-any.whl",
+                    "sha256" : "5f64f6fb9f4aae1471bd4ce1c65e99582479b6bc43996120c4064f87f08a13bc"
+                }
+            ]
+        },
+        {
+            "name" : "python3-pyciede2000",
+            "buildsystem" : "simple",
+            "build-commands" : [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pyciede2000\" --no-build-isolation"
+            ],
+            "sources" : [
+                {
+                    "type" : "file",
+                    "url" : "https://files.pythonhosted.org/packages/f9/e3/b52ecf4711a92187ffa16e8f433af0b32fce7bcc3b8c00543f0592abaa72/pyciede2000-0.0.21-py3-none-any.whl",
+                    "sha256" : "da570372b2c58902b5627568ec3ca2ac2c523d74790022069f89a3b626083d1a"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### Improve cleanup commands

Remove some development-related files to reduce the Flatpak size.

The installed size was reduced from 47.4 MB to 35.5 MB.

### Move Python modules to python3-modules.json file

Move Python modules into the python3-modules file to make it easier to update with the flatpak-pip-generator command.
